### PR TITLE
Add `ntpdate` as CLIENT component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Ambari
+.hash
+archive.zip
+# Java
 .DS_Store
 .class
-.swp
+# Various editors swap files
+.*.sw?
+*~

--- a/configuration/ntpd-config.xml
+++ b/configuration/ntpd-config.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
- 
-<configuration>
 
+<configuration>
   <!-- Define configuration paramaters for service: property name, default value and description (shown as help text) -->
-  
+
   <!-- service log file -->
   <property>
     <name>ntpd.log</name>
     <value>/var/log/ntpd.log</value>
     <description>Log file for ntpd service</description>
-  </property> 
-  
-</configuration>
+  </property>
 
+</configuration>

--- a/configuration/ntpd-config.xml
+++ b/configuration/ntpd-config.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 
-<configuration>
+<!--
+     Hide the custom configuration sections on the Ambari web UI
+     https://developer.ibm.com/hadoop/blog/2016/01/26/ambari-quick-tip-showhide-custom-section-for-stack-services/
+-->
+<configuration supports_final="true" supports_adding_forbidden="true">
   <!-- Define configuration paramaters for service: property name, default value and description (shown as help text) -->
 
   <!-- service log file -->

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -1,46 +1,64 @@
 <?xml version="1.0"?>
 <metainfo>
-    <schemaVersion>2.0</schemaVersion>
-    <services>
-        <service>
-        	<!-- Internal name for service (must be unique) -->
-            <name>NTPD</name>
-            <!-- display name in Ambari UI -->
-            <displayName>ntpd</displayName>
-            <!-- Description of service - will be displayed when user clicks add service -->
-            <comment>The Network Time Protocol daemon (ntpd) is an operating system program that maintains the system time in synchronization with time servers using the Network Time Protocol</comment>
-            <!-- Version of component-->
-            <version>0.0.1</version>
-            <components>
-            	<!-- In this case, there is only one master component -->
-                <component>
-                  <name>NTPD_MASTER</name>
-                  <displayName>ntpd</displayName>
-                  <category>MASTER</category>
-                  <!-- how many of these components are allowed in a cluster -->
-                  <cardinality>1</cardinality>
-                  <!-- reference to (and details of) what script is to be used to install/stop/start/config the service -->
-                  <commandScript>
-                    <script>scripts/master.py</script>
-                    <scriptType>PYTHON</scriptType>
-                    <timeout>5000</timeout>
-                  </commandScript>
-                </component>
-            </components>
-            <!-- what yum packages need to be installed -->
-            <osSpecifics>
-              <osSpecific>
-                <osFamily>redhat6</osFamily>
-                <packages>
-                   <package><name>ntp</name></package>                                                  
-                </packages>
-              </osSpecific>
-            </osSpecifics>
-            <!-- names for config files (under configuration dir) -->
-      	    <configuration-dependencies>
-        	<config-type>ntpd-config</config-type>
-      	    </configuration-dependencies>
-            <restartRequiredAfterChange>false</restartRequiredAfterChange>
-        </service>
-    </services>
+  <schemaVersion>2.0</schemaVersion>
+  <services>
+    <service>
+      <!-- Internal name for service (must be unique) -->
+      <name>NTPD</name>
+      <!-- display name in Ambari UI -->
+      <displayName>ntpd</displayName>
+      <!-- Description of service - will be displayed when user clicks add service -->
+      <comment>The Network Time Protocol daemon (ntpd) is an operating system program that maintains the system time in synchronization with time servers using the Network Time Protocol</comment>
+      <!-- Version of service -->
+      <version>0.1.0</version>
+      <components>
+        <!-- In this case, there is only one master component -->
+        <component>
+          <name>NTPD_MASTER</name>
+          <displayName>ntpd</displayName>
+          <category>MASTER</category>
+          <!-- how many of these components are allowed in a cluster -->
+          <cardinality>1+</cardinality>
+          <!-- reference to (and details of) what script is to be used to install/stop/start/config the service -->
+          <commandScript>
+            <script>scripts/master.py</script>
+            <scriptType>PYTHON</scriptType>
+            <timeout>600</timeout>
+          </commandScript>
+        </component>
+        <component>
+          <name>NTP_CLIENT</name>
+          <displayName>ntpdate</displayName>
+          <category>CLIENT</category>
+          <!-- how many of these components are allowed in a cluster -->
+          <cardinality>1+</cardinality>
+          <!-- reference to (and details of) what script is to be used to install/stop/start/config the service -->
+          <commandScript>
+            <script>scripts/client.py</script>
+            <scriptType>PYTHON</scriptType>
+            <timeout>600</timeout>
+          </commandScript>
+        </component>
+      </components>
+      <!-- what yum packages need to be installed -->
+      <osSpecifics>
+        <osSpecific>
+          <osFamily>redhat6,redhat7</osFamily>
+          <packages>
+            <package>
+              <name>ntp</name>
+            </package>
+            <package>
+              <name>ntpdate</name>
+            </package>
+          </packages>
+        </osSpecific>
+      </osSpecifics>
+      <!-- names for config files (under configuration dir) -->
+      <configuration-dependencies>
+        <config-type>ntpd-config</config-type>
+      </configuration-dependencies>
+      <restartRequiredAfterChange>false</restartRequiredAfterChange>
+    </service>
+  </services>
 </metainfo>

--- a/package/scripts/client.py
+++ b/package/scripts/client.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+from resource_management import *
+
+class Client(Script):
+    def install(self, env):
+        self.install_packages(env)
+        self.configure(env)
+
+    def configure(self, env):
+        import params
+        env.set_params(params)
+        # This is actually not a service, it just syncs system time instantly
+        Execute('service ntpdate start')
+        pass
+
+    # Start means configure for the client
+    def start(self, env, upgrade_type=None):
+        import params
+        env.set_params(params)
+        self.configure(env)
+        pass
+
+    # Do nothing, no need to stop the client
+    def stop(self, env, upgrade_type=None):
+        pass
+
+    def status(self, env):
+        raise ClientComponentHasNoStatus()
+
+if __name__ == "__main__":
+    Client().execute()

--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -1,29 +1,28 @@
-import sys, os, pwd, signal, time
+#!/usr/bin/env python
 from resource_management import *
-from subprocess import call
 
 class Master(Script):
-  def install(self, env):
-  
-    # Install packages listed in metainfo.xml
-    self.install_packages(env)
-    
-    #if any other install steps were needed they can be added here
+    def install(self, env):
+        # Install packages listed in metainfo.xml
+        self.install_packages(env)
+        #if any other install steps were needed they can be added here
 
-  #To stop the service, use the linux service stop command and pipe output to log file
-  def stop(self, env):
-    import params 
-    Execute('service ntpd stop >>' + params.stack_log)
+    #To stop the service, use the linux service stop command and pipe output to log file
+    def stop(self, env):
+        import params
+        env.set_params(params)
+        Execute('service ntpd stop >>' + params.stack_log)
 
-  #To start the service, use the linux service start command and pipe output to log file      
-  def start(self, env):
-    import params
-    Execute('service ntpd start >>' + params.stack_log)
-	
-  #To get status of the, use the linux service status command      
-  def status(self, env):
-    import params
-    Execute('service ntpd status')
+    #To start the service, use the linux service start command and pipe output to log file
+    def start(self, env):
+        import params
+        env.set_params(params)
+        Execute('service ntpd start >>' + params.stack_log)
+
+    #To get status of the, use the linux service status command
+    def status(self, env):
+        import params
+        Execute('service ntpd status')
 
 if __name__ == "__main__":
-  Master().execute()
+    Master().execute()

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -6,4 +6,3 @@ config = Script.get_config()
 
 # store the log file for the service from the 'ntpd.log' property of the 'ntpd-config.xml' file
 stack_log = config['configurations']['ntpd-config']['ntpd.log']
-


### PR DESCRIPTION
Hi!

By this PR I made some improvements to the stack:
- added `NTP_CLIENT` component to make this example stack complete (now you're able to use NTPD as the only one service in your own stack with both master and client - very useful for Ambari starters)
- added redhat7 (RHEL/CentOS 7.x) support
- style fixes like aligning indentation, removing trailing white-spaces and newlines 

Tested on Ambari 2.2.1.

Thanks for the nice tutorial in REAME!
